### PR TITLE
You should avoid that

### DIFF
--- a/cylex_jobs/client/client.lua
+++ b/cylex_jobs/client/client.lua
@@ -1,19 +1,7 @@
 ESX = nil
+TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 local PlayerData = {}
 local PlayerLoaded = false
-Citizen.CreateThread(function()
-    while ESX == nil do
-        TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-        Citizen.Wait(0)
-    end
-
-    while ESX.GetPlayerData().job == nil do
-		Citizen.Wait(10)
-    end
-
-    PlayerData = ESX.GetPlayerData()
-    PlayerLoaded = true
-end)
 
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(xPlayer)


### PR DESCRIPTION
Once you added the dependency, you don't need anymore to while-loop the esx:getSharedObject event.
Avoid of while-loop the player data (ESX.GetPlayerData()), it make unnecessary server->client requests :/